### PR TITLE
Feature/login

### DIFF
--- a/src/components/Layouts/Login.vue
+++ b/src/components/Layouts/Login.vue
@@ -8,8 +8,8 @@ const route = useRoute();
 <template>
   <Layout isHiddenFooter type="styleDisabled">
     <section class="row m-0 login-layout">
-      <div class="col-md-6 image-bg d-none d-sm-block"></div>
-      <div class="col-md-6 d-flex justify-content-center p-3 form-content">
+      <div class="col-lg-6 image-bg d-none d-lg-block"></div>
+      <div class="col-lg-6 d-flex justify-content-center p-3 form-content">
         <img class="deco-img" alt="deco" />
         <RouterView
           class="form-area w-100"
@@ -46,7 +46,7 @@ const route = useRoute();
       content: url("@/assets/loginDeco.svg");
     }
   }
-  @include media-breakpoint-down(md) {
+  @include media-breakpoint-down(lg) {
     min-height: calc(100vh - 72px);
     .form-content {
       align-items: normal;
@@ -61,6 +61,11 @@ const route = useRoute();
         content: url("@/assets/loginDecoMobile.svg");
         width: 100%;
       }
+    }
+  }
+  @media (max-width: 375px) {
+    .is-login {
+      padding-top: 30px !important;
     }
   }
 }

--- a/src/components/User/InformationForm.vue
+++ b/src/components/User/InformationForm.vue
@@ -29,7 +29,10 @@ const defaultTypedSchema = z.object({
   name: z
     .string()
     .min(1, "請輸入姓名")
-    .regex(new RegExp(/^[a-zA-Z\u4e00-\u9fa5\s]+$/), "請輸入正確的名字")
+    .regex(
+      new RegExp(/^[a-zA-Z\u4e00-\u9fa5\s]+$/),
+      "請輸入您的中英文姓名，可包含空白，但不能包含特殊字元"
+    )
     .default(userInformation?.name || ""),
   phone: z
     .string()

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -34,6 +34,12 @@ img {
   border-radius: 0.625rem;
 }
 
+// input、select
+.form-control:focus,
+.form-select:focus {
+  box-shadow: 0 0 0 0.25rem rgba(190, 156, 124, 0.1);
+}
+
 // input 驗證
 .form-control.is-invalid {
   background-image: none;


### PR DESCRIPTION
1. input Foucs State 的 box-shadow 的 rgba(153, 126, 100, 0.25) => rgba(190, 156, 124, 0.1)
2. 修正登入頁手機版 375px 以下(iphone SE) header padding-top: 92px => 30px(有些高度較小的手機版會擋住內容)
3. 姓名欄位驗證錯誤文字：請輸入正確的名字 => 請輸入您的中英文姓名，可包含空白，但不能包含特殊字元
4. 呈第2點，已修改手機版斷點為992